### PR TITLE
Fix broken PIM checksum on interfaces with multiple link-local addresses

### DIFF
--- a/src/pim6.c
+++ b/src/pim6.c
@@ -427,11 +427,7 @@ send_pim6(char *buf, struct sockaddr_in6 *src,
 			    sa6_fmt(src));
 			return;
 		}
-		sndmhpim.msg_control=NULL;
-		sndmhpim.msg_controllen=0;
-		ifindex=src->sin6_scope_id;
 
-		k_set_if(pim6_socket , ifindex);
 		if( IN6_ARE_ADDR_EQUAL(&dst->sin6_addr,
 				       &allnodes_group.sin6_addr) ||
 		    IN6_ARE_ADDR_EQUAL(&dst->sin6_addr,
@@ -443,14 +439,13 @@ send_pim6(char *buf, struct sockaddr_in6 *src,
 			k_set_loop(pim6_socket, TRUE);
 		}
 	}
-	else
-	{
-		sndmhpim.msg_control = (caddr_t)sndcmsgbufpim;
-		sndmhpim.msg_controllen = sndcmsglen;
-		sndpktinfo->ipi6_ifindex=src->sin6_scope_id;
-		memcpy(&sndpktinfo->ipi6_addr, &src->sin6_addr,
-		       sizeof(sndpktinfo->ipi6_addr));
-	}
+
+	sndmhpim.msg_control = (caddr_t)sndcmsgbufpim;
+	sndmhpim.msg_controllen = sndcmsglen;
+	sndpktinfo->ipi6_ifindex=src->sin6_scope_id;
+	memcpy(&sndpktinfo->ipi6_addr, &src->sin6_addr,
+	       sizeof(sndpktinfo->ipi6_addr));
+
 	if (sendmsg(pim6_socket, &sndmhpim, 0) < 0) {
 		if (errno == ENETDOWN)
 			check_vif_state();


### PR DESCRIPTION
When an interface has more than one link-local address then this can
lead to a broken checksum in multicasted PIM messages:

This happens when we choose one link-local address for the IPv6 pseudo
header and PIM checksum calculation but the kernel chooses the other one
for the source address of the packet when transmitting.

For non-multicasted PIM packets the source address is already set
explicitly to the one the checksum was calculated over. With this patch
we do the same for multicasted ones to solve this broken checksum issue.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>

---
Fixes #7, verified with this script:

https://gist.github.com/T-X/9b689b185c72607ab325a275868e01bb

Before:

<pre><code>$ ip netns exec pimtest-router1 tcpdump -l -n -v -i wan0 pim
tcpdump: listening on wan0, link-type EN10MB (Ethernet), capture size 262144 bytes
20:33:58.537463 IP6 (flowlabel 0x13151, hlim 1, next-header PIM (103) payload length: 72) fe80::1 > ff02::d: PIMv2, length 72
        Bootstrap, cksum 0xd8cc (incorrect) tag=5b8 hashmlen=126 BSRprio=0 BSR=fd5c:725:2841::1 (group0: ff00::/8 RPcnt=1 FRPcnt=1 RP0=fd5c:725:2841::1,holdtime=2m30s,prio=0)
20:34:18.552348 IP6 (flowlabel 0x5b502, hlim 1, next-header PIM (103) payload length: 70) fe80::11:22ff:fe00:2 > ff02::d: PIMv2, length 70
        Hello, cksum 0xa47e (correct)
          Hold Time Option (1), length 2, Value: 1m45s
          DR Priority Option (19), length 4, Value: 1
          Generation ID Option (20), length 4, Value: 0x34658b7e
          Address List Option (24), length 18, Value: 
          Address List (Old) Option (65001), length 18, Value: 
20:34:18.552509 IP6 (flowlabel 0x13151, hlim 1, next-header PIM (103) payload length: 106) fe80::1 > ff02::d: PIMv2, length 106
        Hello, cksum 0xa335 (incorrect)
          Hold Time Option (1), length 2, Value: 1m45s
          DR Priority Option (19), length 4, Value: 1
          Generation ID Option (20), length 4, Value: 0x34658b7e
          Address List Option (24), length 36, Value: 
          Address List (Old) Option (65001), length 36, Value: 
^C
3 packets captured
3 packets received by filter
0 packets dropped by kernel
</code></pre>

After:

<pre><code>$ ip netns exec pimtest-router1 tcpdump -l -n -v -i wan0 pim
tcpdump: listening on wan0, link-type EN10MB (Ethernet), capture size 262144 bytes
21:05:31.936275 IP6 (flowlabel 0xbf323, hlim 1, next-header PIM (103) payload length: 72) fe80::11:22ff:fe00:1 > ff02::d: PIMv2, length 72
        Bootstrap, cksum 0xf479 (correct) tag=ea0a hashmlen=126 BSRprio=0 BSR=fd5c:725:2841::1 (group0: ff00::/8 RPcnt=1 FRPcnt=1 RP0=fd5c:725:2841::1,holdtime=2m30s,prio=0)
21:05:51.948365 IP6 (flowlabel 0xbf323, hlim 1, next-header PIM (103) payload length: 106) fe80::11:22ff:fe00:1 > ff02::d: PIMv2, length 106
        Hello, cksum 0xe06f (correct)
          Hold Time Option (1), length 2, Value: 1m45s
          DR Priority Option (19), length 4, Value: 1
          Generation ID Option (20), length 4, Value: 0x1b3a676f
          Address List Option (24), length 36, Value: 
          Address List (Old) Option (65001), length 36, Value: 
21:05:51.948582 IP6 (flowlabel 0x5b502, hlim 1, next-header PIM (103) payload length: 70) fe80::11:22ff:fe00:2 > ff02::d: PIMv2, length 70
        Hello, cksum 0xe1b8 (correct)
          Hold Time Option (1), length 2, Value: 1m45s
          DR Priority Option (19), length 4, Value: 1
          Generation ID Option (20), length 4, Value: 0x1b3a676f
          Address List Option (24), length 18, Value: 
          Address List (Old) Option (65001), length 18, Value: 
^C
3 packets captured
3 packets received by filter
0 packets dropped by kernel
</code></pre>
