### PR TITLE
Fix wrongly ignored PIM bootstrap messages / netlink route check

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -53,7 +53,7 @@ pid_t pid;
 static int getmsg(struct rtmsg *rtm, int msglen, struct rpfctl *rpf);
 
 
-static int addattr32(struct nlmsghdr *n, int maxlen, int type, struct sockaddr_in6 data)
+static int addattr32(struct nlmsghdr *n, int maxlen, int type, struct in6_addr *data)
 {
 	struct rtattr *rta;
 	int len = RTA_LENGTH(16);
@@ -64,7 +64,7 @@ static int addattr32(struct nlmsghdr *n, int maxlen, int type, struct sockaddr_i
 	rta = (struct rtattr *)(((char *)n) + NLMSG_ALIGN(n->nlmsg_len));
 	rta->rta_type = type;
 	rta->rta_len = len;
-	memcpy(RTA_DATA(rta), &data, 16);
+	memcpy(RTA_DATA(rta), data, 16);
 	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + len;
 
 	return 0;
@@ -150,7 +150,7 @@ int k_req_incoming(struct sockaddr_in6 *source, struct rpfctl *rpf)
 	memset(r, 0, sizeof(*r));
 	r->rtm_family = AF_INET6;
 	r->rtm_dst_len = 128;
-	addattr32(n, sizeof(buf), RTA_DST, rpf->source);
+	addattr32(n, sizeof(buf), RTA_DST, &rpf->source.sin6_addr);
 #ifdef CONFIG_RTNL_OLD_IFINFO
 	r->rtm_optlen = n->nlmsg_len - NLMSG_LENGTH(sizeof(*r));
 #endif


### PR DESCRIPTION
When receiving a PIM bootstrap message then pim6sd tended to return
errors like:

  warning - netlink get_route: Network is unreachable
  receive_pim6_bootstrap: can't find a route to the BSR(fd5c:725:2841::1)

Or:

  warning - NETLINK: ifindex=4, but no vif
  receive_pim6_bootstrap: can't find a route to the BSR(fd5c:725:2841::1)

This in turn made pim6sd ignore such PIM bootstrap messages leading to an
empty RP-Set.

Upon receiving a PIM bootstrap message pim6sd asks the kernel for a
route to the address of the PIM bootstrap router. However this netlink
route request has an offset bug: The 128 bits IPv6 address is not stored
in "struct sockaddr_in6" but in its member "struct in6_addr sin6_addr"
instead.

Using the sin6_addr instead made route requests return the correct outgoing
interface index (OIF) again and by that the bootstrap messages were
refreshing the RP-Set successfully.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>

---

Fixes #8, verified with this script:

https://gist.github.com/T-X/a1352078c24f5419c4566f0290f58dde