### PR TITLE
Fix neighbor address check for multi-hop'd RPs

### DIFF
--- a/src/route.c
+++ b/src/route.c
@@ -204,6 +204,14 @@ set_incoming(srcentry_ptr, srctype)
 		log_msg(LOG_DEBUG, 0, "NO ROUTE found for %s", sa6_fmt(&source));
 	    return (FALSE);
 	}
+
+	/*
+	 * Kernel potentially returns router addresses with its sin6_scope_id.
+	 * However we only store the ifindex for link-local addresses.
+	 */
+	if (!IN6_IS_ADDR_LINKLOCAL(&rpfc.rpfneighbor.sin6_addr))
+		rpfc.rpfneighbor.sin6_scope_id = 0;
+
 	srcentry_ptr->incoming = rpfc.iif;
 	neighbor_addr = rpfc.rpfneighbor;
 	/* set the preference for sources that aren't directly connected. */


### PR DESCRIPTION
So far in a setup like:

[router0] <--> [router1]:BR <--> [router2]:RP

router0 was unable to correctly set router2 in its RP-Set after
receiving a bootstrap message from router1:

---------------------------RP-Set----------------------------
Current BSR address: fd5c:725:2841::2 Prio: 0 Timeout: 125
RP-address(Upstream)/Group prefix             Prio Hold Age
fd5c:725:2841:1::3(none)
ff13:23:42:ffff::/64 0 150 115

Which was caused by a failing neighbor address check:

[...]
23:19:07.988 NETLINK: ask path to fd5c:725:2841:1::3
23:19:07.988 NETLINK: vif 0, ifindex=5
23:19:07.988 NETLINK: gateway is fd5c:725:2841::2
23:19:07.988 For src fd5c:725:2841:1::3, iif is wan0, next hop router is fd5c:725:2841::2%5: NOT A PIM ROUTER
[...]

This failing check could further be tracked down to the aux_addr check
in set_incoming():

This function queries the kernel for a router address to the RP
(fd5c:725:2841:1::3). The kernel correctly returns router1
(fd5c:725:2841::2%5).

Which would then be checked against the stored auxiliary addresses
reported earlier via a PIM Hello.

Unfortunately, so far this check (inet6_equal() ) would fail because the
router address returned by the kernel would have a sin6_scope_id set
but the addresses in aux_addr were stored without a sin6_scope_id.

This patch fixes this root cause by storing the sin6_scope_id for
aux_addr'es, too.

Tested on a 4.19.28 Linux kernel as provided by Debian Sid.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>