### PR TITLE
Fix use-after-free bug with embedded-RP addresses

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -355,6 +355,7 @@ void
 age_routes()
 {
     cand_rp_t      	*cand_rp_ptr;
+    cand_rp_t      	*cand_rp_ptr_next;
     grpentry_t     	*grpentry_ptr;
     grpentry_t     	*grpentry_ptr_next;
     mrtentry_t     	*mrtentry_grp;
@@ -373,6 +374,7 @@ age_routes()
     int             	dont_calc_action;
     int             	did_switch_flag;
     rp_grp_entry_t 	*rp_grp_entry_ptr;
+    rp_grp_entry_t 	*rp_grp_entry_ptr_next;
     kernel_cache_t 	*kernel_cache_ptr;
     kernel_cache_t 	*kernel_cache_next;
     u_long          	curr_bytecnt;
@@ -421,9 +423,9 @@ age_routes()
     /* Scan the (*,*,RP) entries */
 
     for (cand_rp_ptr = cand_rp_list; cand_rp_ptr != (cand_rp_t *) NULL;
-	 cand_rp_ptr = cand_rp_ptr->next)
+	 cand_rp_ptr = cand_rp_ptr_next)
     {
-	
+	cand_rp_ptr_next = cand_rp_ptr->next;
 	rpentry_ptr = cand_rp_ptr->rpentry;
 
 	/*
@@ -670,8 +672,9 @@ age_routes()
 
 	for (rp_grp_entry_ptr = cand_rp_ptr->rp_grp_next;
 	     rp_grp_entry_ptr != (rp_grp_entry_t *) NULL;
-	     rp_grp_entry_ptr = rp_grp_entry_ptr->rp_grp_next)
+	     rp_grp_entry_ptr = rp_grp_entry_ptr_next)
 	{
+	     rp_grp_entry_ptr_next = rp_grp_entry_ptr->rp_grp_next;
 
 	    for (grpentry_ptr = rp_grp_entry_ptr->grplink;
 		 grpentry_ptr != (grpentry_t *) NULL;


### PR DESCRIPTION
When using embedded-RP addresses pim6sd would sometimes crash on the
first call to age_routes(). valgrind was able to track this down to the
following use-after-free issue:

<pre><code>$ valgrind --track-origins=yes ./src/pim6sd -f ./pim6sd.conf
[...]
04:20:42.949 warning - setsockopt MRT6_DEL_MFC: No such file or directory
==2722== Invalid read of size 8
==2722==    at 0x1271A9: age_routes (timer.c:673)
==2722==    by 0x11492D: timer (main.c:577)
==2722==    by 0x10AF09: age_callout_queue (callout.c:130)
==2722==    by 0x10AA55: main (main.c:523)
==2722==  Address 0x4a95240 is 0 bytes inside a block of size 64 free'd
==2722==    at 0x48369AB: free (vg_replace_malloc.c:530)
==2722==    by 0x119F9B: delete_grpentry (mrt.c:611)
==2722==    by 0x11A26C: delete_mrtentry (mrt.c:701)
==2722==    by 0x127184: age_routes (timer.c:1215)
==2722==    by 0x11492D: timer (main.c:577)
==2722==    by 0x10AF09: age_callout_queue (callout.c:130)
==2722==    by 0x10AA55: main (main.c:523)
==2722==  Block was alloc'd at
==2722==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==2722==    by 0x12649A: add_rp_grp_entry (rp.c:658)
==2722==    by 0x1258A5: rp_grp_match (rp.c:1274)
==2722==    by 0x11AE27: find_route (mrt.c:294)
==2722==    by 0x124981: process_cache_miss (route.c:1007)
==2722==    by 0x124981: process_kernel_call (route.c:924)
==2722==    by 0x10AB0F: main (main.c:535)
==2722==
==2722== Invalid read of size 8
==2722==    at 0x1271BF: age_routes (timer.c:424)
==2722==    by 0x11492D: timer (main.c:577)
==2722==    by 0x10AF09: age_callout_queue (callout.c:130)
==2722==    by 0x10AA55: main (main.c:523)
==2722==  Address 0x4a95140 is 0 bytes inside a block of size 32 free'd
==2722==    at 0x48369AB: free (vg_replace_malloc.c:530)
==2722==    by 0x125F6A: delete_rp_grp_entry (rp.c:756)
==2722==    by 0x119F9B: delete_grpentry (mrt.c:611)
==2722==    by 0x11A26C: delete_mrtentry (mrt.c:701)
==2722==    by 0x127184: age_routes (timer.c:1215)
==2722==    by 0x11492D: timer (main.c:577)
==2722==    by 0x10AF09: age_callout_queue (callout.c:130)
==2722==    by 0x10AA55: main (main.c:523)
==2722==  Block was alloc'd at
==2722==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==2722==    by 0x12645A: add_cand_rp (rp.c:409)
==2722==    by 0x12645A: add_rp_grp_entry (rp.c:586)
==2722==    by 0x1258A5: rp_grp_match (rp.c:1274)
==2722==    by 0x11AE27: find_route (mrt.c:294)
==2722==    by 0x124981: process_cache_miss (route.c:1007)
==2722==    by 0x124981: process_kernel_call (route.c:924)
==2722==    by 0x10AB0F: main (main.c:535)
[...]
</code></pre>

Storing the affected two next pointers before the cand_rp_t and
rp_grp_entry_t pointers are free()'d fixes the issue.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>

---

Fixes: #18