### PR TITLE
Avoid uninitialized bytes to syscalls

### DIFF
--- a/src/kern.c
+++ b/src/kern.c
@@ -332,12 +332,11 @@ k_chg_mfc(socket, source, group, iif, oifs, rp_addr)
     mifi_t          vifi;
     struct uvif    *v;
 
+    memset(&mc, 0, sizeof(mc));
     mc.mf6cc_origin = *source;
     mc.mf6cc_mcastgrp = *group;
     mc.mf6cc_parent = iif;
 
-
-    IF_ZERO(&mc.mf6cc_ifset);
 
     for (vifi = 0, v = uvifs; vifi < numvifs; vifi++, v++)
     {

--- a/src/kern.c
+++ b/src/kern.c
@@ -297,6 +297,7 @@ k_del_mfc(int socket, struct sockaddr_in6 * source, struct sockaddr_in6 * group)
 {
     struct mf6cctl  mc;
 
+    memset(&mc, 0, sizeof(mc));
     mc.mf6cc_origin = *source;
     mc.mf6cc_mcastgrp = *group;
 

--- a/src/kern.c
+++ b/src/kern.c
@@ -260,6 +260,8 @@ k_add_vif(int socket, mifi_t vifi, struct uvif * v)
 {
     struct mif6ctl  mc;
 
+    memset(&mc, 0, sizeof(mc));
+
     mc.mif6c_mifi = vifi;
     mc.mif6c_flags = v->uv_flags;
 

--- a/src/pim6.c
+++ b/src/pim6.c
@@ -217,6 +217,7 @@ init_pim6()
 	if (sndcmsgbufpim == NULL &&
 	    (sndcmsgbufpim = malloc(sndcmsglen)) == NULL)
 		log_msg(LOG_ERR, 0, "malloc failed");
+	memset(sndcmsgbufpim, 0, sndcmsglen);
 	sndmhpim.msg_control = (caddr_t)sndcmsgbufpim;
 	sndmhpim.msg_controllen = sndcmsglen;
 	cmsgp=(struct cmsghdr *)sndcmsgbufpim;


### PR DESCRIPTION
Here are a few patches to make valgrind happy. Nothing critical at the moment, as far as I can tell by cross checking with the Linux kernel code. Mainly some uninitialized variables passed to the kernel which are not used in the kernel (yet?) and some funny, uninitialized alignment bytes for the last patch.