### PR TITLE
Memory cleanup on shutdown

### DIFF
--- a/src/cftoken.l
+++ b/src/cftoken.l
@@ -686,6 +686,8 @@ cfparse(strict, debugonly)
 
 	if ((yyparse() || yyerrorcount) && strict) {
 		fclose(yyin);
+		yylex_destroy();
+
 		if (yyerrorcount) {
 			yyerror("fatal parse failure: exiting (%d errors)",
 				yyerrorcount);
@@ -695,6 +697,8 @@ cfparse(strict, debugonly)
 	}
 
 	fclose(yyin);
+	yylex_destroy();
+
 	YIPSDP(PLOG("parse successed.\n"));
 
 	return cf_post_config();

--- a/src/main.c
+++ b/src/main.c
@@ -609,6 +609,7 @@ cleanup()
     k_stop_pim(mld6_socket);
 
     free_rp6();
+    free_pim6_mrt();
     free_pim6();
     free_mld6();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -609,6 +609,7 @@ cleanup()
     k_stop_pim(mld6_socket);
 
     free_pim6();
+    free_mld6();
 }
 
 /*

--- a/src/main.c
+++ b/src/main.c
@@ -607,6 +607,7 @@ cleanup()
     ;
 
     stop_all_vifs();
+    free_all_callouts();
     k_stop_pim(mld6_socket);
 
     free_rp6();

--- a/src/main.c
+++ b/src/main.c
@@ -607,6 +607,8 @@ cleanup()
     ;
 
     k_stop_pim(mld6_socket);
+
+    free_pim6();
 }
 
 /*

--- a/src/main.c
+++ b/src/main.c
@@ -606,6 +606,7 @@ cleanup()
      */
     ;
 
+    stop_all_vifs();
     k_stop_pim(mld6_socket);
 
     free_rp6();

--- a/src/main.c
+++ b/src/main.c
@@ -608,6 +608,7 @@ cleanup()
 
     k_stop_pim(mld6_socket);
 
+    free_rp6();
     free_pim6();
     free_mld6();
 }

--- a/src/mld6.c
+++ b/src/mld6.c
@@ -274,6 +274,14 @@ init_mld6()
 	    "Couldn't register mld6_read as an input handler");
 }
 
+void
+free_mld6()
+{
+	free(mld6_recv_buf);
+	free(mld6_send_buf);
+	free(rcvcmsgbuf);
+}
+
 /* Read an MLD message */
 static void
 mld6_read(i, rfd)

--- a/src/mld6.c
+++ b/src/mld6.c
@@ -280,6 +280,12 @@ free_mld6()
 	free(mld6_recv_buf);
 	free(mld6_send_buf);
 	free(rcvcmsgbuf);
+
+	if (sndcmsgbuf) {
+		free(sndcmsgbuf);
+		sndcmsgbuf = NULL;
+		ctlbuflen = 0;
+	}
 }
 
 /* Read an MLD message */

--- a/src/mld6.h
+++ b/src/mld6.h
@@ -63,6 +63,7 @@ extern struct sockaddr_in6 allnodes_group;
 extern char *mld6_send_buf;
 
 void init_mld6 (void);
+void free_mld6 (void);
 int send_mld6 __P((int type, int code, struct sockaddr_in6 *src,
 		   struct sockaddr_in6 *dst, struct in6_addr *group,
 		   int index, int delay, int datalen, int alert));

--- a/src/mrt.c
+++ b/src/mrt.c
@@ -154,6 +154,12 @@ init_pim6_mrt()
     grplist->grp_route = (mrtentry_t *) NULL;
 }
 
+void
+free_pim6_mrt()
+{
+    free(srclist);
+    free(grplist);
+}
 
 grpentry_t     *
 find_group(group)

--- a/src/mrt.h
+++ b/src/mrt.h
@@ -304,6 +304,7 @@ extern srcentry_t *srclist;
 extern grpentry_t *grplist;
 
 extern void init_pim6_mrt (void);
+extern void free_pim6_mrt (void);
 extern mrtentry_t   *find_route  __P((struct sockaddr_in6 *source,
                           	      struct sockaddr_in6 *group,
                           	      u_int16 flags, char create)); 

--- a/src/pim6.c
+++ b/src/pim6.c
@@ -233,6 +233,15 @@ init_pim6()
 	build_jp_message_pool_counter = 0;
 }
 
+void
+free_pim6()
+{
+	free(pim6_recv_buf);
+	free(pim6_send_buf);
+	free(rcvcmsgbufpim);
+	free(sndcmsgbufpim);
+}
+
 /* Read a PIM message */
 
 static void

--- a/src/pim6.h
+++ b/src/pim6.h
@@ -65,6 +65,7 @@ extern char *pim6_send_buf;
 extern int 	pim6_socket;
 
 void init_pim6 (void);
+void free_pim6 (void);
 extern void send_pim6        __P((char *buf, struct sockaddr_in6 *src,
                          struct sockaddr_in6 *dst, int type, 
                          int datalen));

--- a/src/rp.c
+++ b/src/rp.c
@@ -256,6 +256,12 @@ init_rp6()
 }
 
 void
+free_rp6()
+{
+	free(cand_rp_adv_message.buffer);
+}
+
+void
 init_bsr6()
 {
     struct sockaddr_in6 *sa6 = NULL;

--- a/src/rp.h
+++ b/src/rp.h
@@ -88,6 +88,7 @@ struct staticrp {
 };
 
 extern void      init_rp6	(void);
+extern void      free_rp6	(void);
 extern void      init_bsr6	(void);
 void delete_rp_list( cand_rp_t **used_cand_rp_list , grp_mask_t **used_grp_mask_list );
 u_int16 bootstrap_initial_delay (void);


### PR DESCRIPTION
Some memory cleanups on shutdown for allocations which were performed on initialization. This makes valgrind happy regarding memory leaks for a single, isolated router without a BSR.

The cleanup() procedure does not 100% mirror the init part yet but should hopefully be a good start. At least the valgrind memory leak output should be a bit more manageable.

Other ToDos are still to reuse the cleanup() function in the restart() one and test (or remove?) restart(). And to exit cleanly upon errors.