### PR TITLE
Header and macro cleanups for musl.

### DIFF
--- a/src/callout.c
+++ b/src/callout.c
@@ -33,6 +33,8 @@
 #include <syslog.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/select.h>
+#include <sys/types.h>
 #include "defs.h"
 #include "debug.h"
 #include "callout.h"

--- a/src/cfparse.y
+++ b/src/cfparse.y
@@ -110,10 +110,10 @@ static int debugonly;
 
 extern int yylex (void);
 
-static struct attr_list *add_attribute_flag __P((struct attr_list *, int,
-	unsigned int));
-static struct attr_list *add_attribute_num __P((struct attr_list *, int,
-	double));
+static struct attr_list *add_attribute_flag (struct attr_list *, int,
+	unsigned int);
+static struct attr_list *add_attribute_num (struct attr_list *, int,
+	double);
 static void free_attr_list (struct attr_list *);
 static int param_config (void);
 static int phyint_config (void);

--- a/src/crc.c
+++ b/src/crc.c
@@ -41,7 +41,6 @@
  */
 /* CRC implantation : stolen from RFC 2083 section 15.*/
 
-#include <sys/cdefs.h>
 #include "crc.h"
 
 /* Table of CRCs of all 8-bit messages. */

--- a/src/debug.h
+++ b/src/debug.h
@@ -132,17 +132,17 @@ extern FILE *log_fp;
 #define YIPSDEBUG(lev,arg)
 #endif /* defined(YIPS_DEBUG) */
 
-extern char *packet_kind        __P((u_int proto, u_int type,
-                         u_int code));
-extern int  debug_kind      __P((u_int proto, u_int type,
-                         u_int code));
+extern char *packet_kind        (u_int proto, u_int type,
+                         u_int code);
+extern int  debug_kind      (u_int proto, u_int type,
+                         u_int code);
 extern int debug_list(int mask, char *buf, size_t len);
 extern int debug_parse(char *arg);
 extern void log_stack(void);
 extern void log_msg         (int, int, char *, ...)
 	__attribute__((__format__(__printf__, 3, 4)));
-extern int  log_level       __P((u_int proto, u_int type,
-                         u_int code));
+extern int  log_level       (u_int proto, u_int type,
+                         u_int code);
 extern void dump            (int i);
 extern void fdump           (int i);
 extern void cdump           (int i);

--- a/src/inet6.h
+++ b/src/inet6.h
@@ -51,28 +51,28 @@
 
 extern int numerichost;
 
-extern int  inet6_equal __P((struct sockaddr_in6 *sa1,
-                     struct sockaddr_in6 *sa2)); 
-extern int  inet6_lessthan  __P((struct sockaddr_in6 *sa1,
-                     struct sockaddr_in6 *sa2));
-extern int  inet6_localif_address __P((struct sockaddr_in6 *sa,
-                       struct uvif *v));
-extern int  inet6_greaterthan __P((struct sockaddr_in6 *sa1,
-                       struct sockaddr_in6 *sa2));
-extern int  inet6_match_prefix __P((struct sockaddr_in6 *sa1,
+extern int  inet6_equal (struct sockaddr_in6 *sa1,
+                     struct sockaddr_in6 *sa2); 
+extern int  inet6_lessthan  (struct sockaddr_in6 *sa1,
+                     struct sockaddr_in6 *sa2);
+extern int  inet6_localif_address (struct sockaddr_in6 *sa,
+                       struct uvif *v);
+extern int  inet6_greaterthan (struct sockaddr_in6 *sa1,
+                       struct sockaddr_in6 *sa2);
+extern int  inet6_match_prefix (struct sockaddr_in6 *sa1,
 				   struct sockaddr_in6 * sa2,
-				   struct in6_addr * mask));
-extern int inet6_same_prefix __P((struct sockaddr_in6 * sa1,
+				   struct in6_addr * mask);
+extern int inet6_same_prefix (struct sockaddr_in6 * sa1,
                     struct sockaddr_in6 *sa2,
-                    struct in6_addr *mask));
+                    struct in6_addr *mask);
 extern int  inet6_mask2plen    (struct in6_addr *mask);
 extern int  inet6_uvif2scopeid (struct sockaddr_in6 *sa, struct uvif *v);
 extern int  inet6_valid_host (struct sockaddr_in6 *addr);
 extern char *sa6_fmt  (struct sockaddr_in6 *sa6);
 extern char *inet6_fmt  (struct in6_addr *addr);
 extern char *ifindex2str    (int ifindex);
-extern char *net6name   __P((struct in6_addr *prefix, 
-                     struct in6_addr *mask));
+extern char *net6name   (struct in6_addr *prefix, 
+                     struct in6_addr *mask);
 extern void init_sin6(struct sockaddr_in6 *);
 extern socklen_t get_sa_len(struct sockaddr *);
 

--- a/src/kern.h
+++ b/src/kern.h
@@ -53,23 +53,23 @@ extern void     k_set_rcvbuf    (int socket, int bufsize, int minsize);
 extern void     k_set_hlim       (int socket, int t);
 extern void     k_set_loop      (int socket, int l);
 extern void     k_set_if        (int socket, u_int ifindex);
-extern void     k_join          __P((int socket, struct in6_addr *grp,
-                     u_int ifindex));
-extern void     k_leave         __P((int socket, struct in6_addr *grp,
-                     u_int ifindex));
+extern void     k_join          (int socket, struct in6_addr *grp,
+                     u_int ifindex);
+extern void     k_leave         (int socket, struct in6_addr *grp,
+                     u_int ifindex);
 extern void     k_init_pim     (int);
 extern void     k_stop_pim      (int);
-extern int      k_del_mfc       __P((int socket, struct sockaddr_in6 *source,
-                     struct sockaddr_in6 *group));
-extern int      k_chg_mfc       __P((int socket, struct sockaddr_in6 *source,
+extern int      k_del_mfc       (int socket, struct sockaddr_in6 *source,
+                     struct sockaddr_in6 *group);
+extern int      k_chg_mfc       (int socket, struct sockaddr_in6 *source,
                      struct sockaddr_in6 *group, mifi_t iif, 
-                     if_set *oifs, struct sockaddr_in6 *rp_addr));
+                     if_set *oifs, struct sockaddr_in6 *rp_addr);
 extern void     k_add_vif       (int socket, mifi_t vifi, struct uvif *v);
 extern void     k_del_vif       (int socket, mifi_t vifi);
 extern int      k_get_vif_count (mifi_t vifi, struct vif_count *retval);
-extern int      k_get_sg_cnt    __P((int socket, struct sockaddr_in6 *source,
+extern int      k_get_sg_cnt    (int socket, struct sockaddr_in6 *source,
                      struct sockaddr_in6 *group,
-                     struct sg_count *retval));
+                     struct sg_count *retval);
 
 
 

--- a/src/mld6.c
+++ b/src/mld6.c
@@ -138,8 +138,8 @@ static u_int16_t rtalert_code;
 
 static void mld6_read (int i, fd_set * fds);
 static void accept_mld6 (int len);
-static void make_mld6_msg __P((int, int, struct sockaddr_in6 *,
-	struct sockaddr_in6 *, struct in6_addr *, int, int, int, int));
+static void make_mld6_msg (int, int, struct sockaddr_in6 *,
+	struct sockaddr_in6 *, struct in6_addr *, int, int, int, int);
 
 #ifndef IP6OPT_ROUTER_ALERT	/* XXX to be compatible older systems */
 #define IP6OPT_ROUTER_ALERT IP6OPT_RTALERT

--- a/src/mld6.h
+++ b/src/mld6.h
@@ -64,9 +64,9 @@ extern char *mld6_send_buf;
 
 void init_mld6 (void);
 void free_mld6 (void);
-int send_mld6 __P((int type, int code, struct sockaddr_in6 *src,
+int send_mld6 (int type, int code, struct sockaddr_in6 *src,
 		   struct sockaddr_in6 *dst, struct in6_addr *group,
-		   int index, int delay, int datalen, int alert));
+		   int index, int delay, int datalen, int alert);
 
 #ifndef MLD_LISTENER_QUERY
 #  ifdef MLD6_LISTENER_QUERY

--- a/src/mld6_proto.c
+++ b/src/mld6_proto.c
@@ -131,8 +131,8 @@
 static int DeleteTimer (int id);
 static void SendQuery (void *arg);
 static int SetQueryTimer
-__P((struct listaddr * g, int mifi, int to_expire,
-     int q_time));
+(struct listaddr * g, int mifi, int to_expire,
+     int q_time);
 
 /*
  * Send group membership queries on that interface if I am querier.

--- a/src/mld6_proto.h
+++ b/src/mld6_proto.h
@@ -99,28 +99,28 @@ typedef struct
 		MLD6_QUERY_RESPONSE_INTERVAL / MLD6_TIMER_SCALE)
 
 extern void     query_groups            (struct uvif *v);
-extern int      check_grp_membership    __P((struct uvif *v,
-					     struct sockaddr_in6 *group));
-extern void     accept_listener_query   __P((struct sockaddr_in6 *src,
+extern int      check_grp_membership    (struct uvif *v,
+					     struct sockaddr_in6 *group);
+extern void     accept_listener_query   (struct sockaddr_in6 *src,
 					     struct in6_addr *dst,
 					     struct in6_addr *group,
-					     int tmo));
-extern void     accept_listener_report  __P((struct sockaddr_in6 *src,
+					     int tmo);
+extern void     accept_listener_report  (struct sockaddr_in6 *src,
 					     struct in6_addr *dst,
-					     struct in6_addr *group));
-extern void     accept_listener_done    __P((struct sockaddr_in6 *src,
+					     struct in6_addr *group);
+extern void     accept_listener_done    (struct sockaddr_in6 *src,
 					     struct in6_addr *dst,
-					     struct in6_addr *group));
-extern struct listaddr *check_multicast_listener __P((struct uvif *v,
-					     struct sockaddr_in6 *group));
+					     struct in6_addr *group);
+extern struct listaddr *check_multicast_listener (struct uvif *v,
+					     struct sockaddr_in6 *group);
 
-extern void     recv_listener_report	__P((mifi_t,
+extern void     recv_listener_report	(mifi_t,
 					     struct sockaddr_in6 *src,
 					     struct sockaddr_in6 *group,
-					     int mld_version));
-extern void     recv_listener_done      __P((mifi_t,
+					     int mld_version);
+extern void     recv_listener_done      (mifi_t,
 					     struct sockaddr_in6 *src,
-					     struct sockaddr_in6 *group));
+					     struct sockaddr_in6 *group);
 extern int	SetTimer (int mifi, struct listaddr * g);
 extern void	DelVif (void *);
 

--- a/src/mld6v2_proto.h
+++ b/src/mld6v2_proto.h
@@ -49,20 +49,20 @@
 
 extern void query_groupsV2 (struct uvif * v);
 extern void Send_GS_QueryV2 (void *arg);
-extern void accept_listenerV2_query __P((struct sockaddr_in6 * src,
+extern void accept_listenerV2_query (struct sockaddr_in6 * src,
 					 struct in6_addr * dst,
 					 char *query_message,
-					 int datalen));
-extern void accept_listenerV2_report __P((struct sockaddr_in6 * src,
+					 int datalen);
+extern void accept_listenerV2_report (struct sockaddr_in6 * src,
 					  struct in6_addr * dst,
 					  char *report_message,
-					  int datalen));
-extern struct listaddr *check_multicastV2_listener __P((struct uvif * v,
+					  int datalen);
+extern struct listaddr *check_multicastV2_listener (struct uvif * v,
 							struct sockaddr_in6 *
 							group,
 							struct listaddr ** g,
 							struct sockaddr_in6 *
-							source));
+							source);
 extern int SetTimerV2 (int vifi, struct listaddr * g, struct listaddr * s);
 extern void mld_shift_to_v2mode (void * );
 extern int SetTimerV1compat (mifi_t, struct listaddr *, int);

--- a/src/mrt.c
+++ b/src/mrt.c
@@ -82,39 +82,39 @@ grpentry_t     *grplist;
  * Local functions definition
  */
 static srcentry_t *create_srcentry 	(struct sockaddr_in6 *source);
-static int search_srclist 			__P((struct sockaddr_in6 *source ,	
-     								srcentry_t ** sourceEntry));
+static int search_srclist 			(struct sockaddr_in6 *source ,	
+     								srcentry_t ** sourceEntry);
 
-static int search_srcmrtlink 		__P((srcentry_t * srcentry_ptr,
+static int search_srcmrtlink 		(srcentry_t * srcentry_ptr,
 				                  	struct sockaddr_in6 *group,
-				                    mrtentry_t ** mrtPtr));
+				                    mrtentry_t ** mrtPtr);
 
-static void insert_srcmrtlink 		__P((mrtentry_t * elementPtr,
+static void insert_srcmrtlink 		(mrtentry_t * elementPtr,
 				                    mrtentry_t * insertPtr,
-				                  	srcentry_t * srcListPtr));
+				                  	srcentry_t * srcListPtr);
 
 static grpentry_t *create_grpentry  (struct sockaddr_in6 *group);
 
-static int search_grplist 			__P((struct sockaddr_in6 *group,
-				                 		grpentry_t ** groupEntry));
+static int search_grplist 			(struct sockaddr_in6 *group,
+				                 		grpentry_t ** groupEntry);
 
-static int search_grpmrtlink 		__P((grpentry_t * grpentry_ptr,
+static int search_grpmrtlink 		(grpentry_t * grpentry_ptr,
 				                      	 struct sockaddr_in6 *source,
-				                      	 mrtentry_t ** mrtPtr));
+				                      	 mrtentry_t ** mrtPtr);
 
-static void insert_grpmrtlink 		__P((mrtentry_t * elementPtr,
+static void insert_grpmrtlink 		(mrtentry_t * elementPtr,
 				                     	 mrtentry_t * insertPtr,
-				                  		 grpentry_t * grpListPtr));
+				                  		 grpentry_t * grpListPtr);
 
-static mrtentry_t *alloc_mrtentry 	__P((srcentry_t * srcentry_ptr,
-				                		grpentry_t * grpentry_ptr));
+static mrtentry_t *alloc_mrtentry 	(srcentry_t * srcentry_ptr,
+				                		grpentry_t * grpentry_ptr);
 
-static mrtentry_t *create_mrtentry 	__P((srcentry_t * srcentry_ptr,
+static mrtentry_t *create_mrtentry 	(srcentry_t * srcentry_ptr,
 				                  		grpentry_t * grpentry_ptr,
-					                    u_int16 flags));
+					                    u_int16 flags);
 
-static void move_kernel_cache 		__P((mrtentry_t * mrtentry_ptr,
-				                        u_int16 flags));
+static void move_kernel_cache 		(mrtentry_t * mrtentry_ptr,
+				                        u_int16 flags);
 
 void
 init_pim6_mrt()

--- a/src/mrt.h
+++ b/src/mrt.h
@@ -305,22 +305,22 @@ extern grpentry_t *grplist;
 
 extern void init_pim6_mrt (void);
 extern void free_pim6_mrt (void);
-extern mrtentry_t   *find_route  __P((struct sockaddr_in6 *source,
+extern mrtentry_t   *find_route  (struct sockaddr_in6 *source,
                           	      struct sockaddr_in6 *group,
-                          	      u_int16 flags, char create)); 
+                          	      u_int16 flags, char create); 
 extern grpentry_t *find_group (struct sockaddr_in6 *group);
 extern srcentry_t *find_source (struct sockaddr_in6 *source);
 extern void delete_mrtentry (mrtentry_t *mrtentry_ptr);
 extern void delete_srcentry (srcentry_t *srcentry_ptr);
 extern void delete_grpentry (grpentry_t *grpentry_ptr);
 extern void delete_mrtentry_all_kernel_cache (mrtentry_t *mrtentry_ptr);
-extern void delete_single_kernel_cache __P((mrtentry_t *mrtentry_ptr,
-                        		    	kernel_cache_t *kernel_cache_ptr));
-extern void delete_single_kernel_cache_addr __P((mrtentry_t *mrtentry_ptr,
+extern void delete_single_kernel_cache (mrtentry_t *mrtentry_ptr,
+                        		    	kernel_cache_t *kernel_cache_ptr);
+extern void delete_single_kernel_cache_addr (mrtentry_t *mrtentry_ptr,
                              			struct sockaddr_in6 *source,
-                             			struct sockaddr_in6 *group));
-extern void add_kernel_cache __P((mrtentry_t *mrtentry_ptr,
+                             			struct sockaddr_in6 *group);
+extern void add_kernel_cache (mrtentry_t *mrtentry_ptr,
                          	  struct sockaddr_in6 *source,
-				  struct sockaddr_in6 *group, u_int16 flags));
+				  struct sockaddr_in6 *group, u_int16 flags);
 
 #endif

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -35,7 +35,7 @@
 #include <linux/mroute6.h>
 #endif
 #include <syslog.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <time.h>
 #include "defs.h"
 #include "vif.h"

--- a/src/pim6.c
+++ b/src/pim6.c
@@ -137,8 +137,8 @@ static int rcvcmsglen;
  */
 static void pim6_read   (int f, fd_set *rfd);
 static void accept_pim6 (int recvlen);
-static int pim6_cksum __P((u_int16_t *, struct in6_addr *,
-               struct in6_addr *, int));
+static int pim6_cksum (u_int16_t *, struct in6_addr *,
+               struct in6_addr *, int);
 
 
 

--- a/src/pim6.h
+++ b/src/pim6.h
@@ -66,9 +66,9 @@ extern int 	pim6_socket;
 
 void init_pim6 (void);
 void free_pim6 (void);
-extern void send_pim6        __P((char *buf, struct sockaddr_in6 *src,
+extern void send_pim6        (char *buf, struct sockaddr_in6 *src,
                          struct sockaddr_in6 *dst, int type, 
-                         int datalen));
+                         int datalen);
 
 
 #endif

--- a/src/pim6_proto.h
+++ b/src/pim6_proto.h
@@ -54,42 +54,42 @@ extern int               build_jp_message_pool_counter;
 extern struct sockaddr_in6 sockaddr6_any;
 extern struct sockaddr_in6 sockaddr6_d;
 
-extern int receive_pim6_hello         __P((struct sockaddr_in6 *src,
-                       char *pim_message, int datalen));
+extern int receive_pim6_hello         (struct sockaddr_in6 *src,
+                       char *pim_message, int datalen);
 
 extern int send_pim6_hello            (struct uvif *v, u_int16 holdtime);
 extern void delete_pim6_nbr           (pim_nbr_entry_t *nbr_delete);
 
-extern int  receive_pim6_register    __P((struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
-                         char *pim_message, int datalen));
+extern int  receive_pim6_register    (struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
+                         char *pim_message, int datalen);
 extern int  send_pim6_null_register  (mrtentry_t *r);
-extern int  receive_pim6_register_stop __P((struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
+extern int  receive_pim6_register_stop (struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
                            char *pim_message,
-                           int datalen));
+                           int datalen);
 extern int  send_pim6_register   (char *pkt);
-extern int  receive_pim6_join_prune  __P((struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
-                         char *pim_message, int datalen));
-extern int  join_or_prune       __P((mrtentry_t *mrtentry_ptr,  
-                         pim_nbr_entry_t *upstream_router));
-extern int  receive_pim6_assert  __P((struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
-                         char *pim_message, int datalen));
-extern int  send_pim6_assert     __P((struct sockaddr_in6 *source, struct sockaddr_in6 *group,
+extern int  receive_pim6_join_prune  (struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
+                         char *pim_message, int datalen);
+extern int  join_or_prune       (mrtentry_t *mrtentry_ptr,  
+                         pim_nbr_entry_t *upstream_router);
+extern int  receive_pim6_assert  (struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
+                         char *pim_message, int datalen);
+extern int  send_pim6_assert     (struct sockaddr_in6 *source, struct sockaddr_in6 *group,
                          mifi_t vifi,
-                         mrtentry_t *mrtentry_ptr));
-extern int  send_periodic_pim6_join_prune __P((mifi_t vifi, 
+                         mrtentry_t *mrtentry_ptr);
+extern int  send_periodic_pim6_join_prune (mifi_t vifi, 
                           pim_nbr_entry_t *pim_nbr,
-                          u_int16 holdtime));
-extern int  add_jp_entry        __P((pim_nbr_entry_t *pim_nbr,
+                          u_int16 holdtime);
+extern int  add_jp_entry        (pim_nbr_entry_t *pim_nbr,
                          u_int16 holdtime, struct sockaddr_in6 *group,
                          u_int8 grp_msklen, struct sockaddr_in6 *source,  
                          u_int8 src_msklen,
                          u_int16 addr_flags,  
-                         u_int8 join_prune));
+                         u_int8 join_prune);
 extern void pack_and_send_jp6_message (pim_nbr_entry_t *pim_nbr);
-extern int  receive_pim6_cand_rp_adv __P((struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
-                         char *pim_message, int datalen));
-extern int  receive_pim6_bootstrap   __P((struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
-                         char *pim_message, int datalen));
+extern int  receive_pim6_cand_rp_adv (struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
+                         char *pim_message, int datalen);
+extern int  receive_pim6_bootstrap   (struct sockaddr_in6 *src, struct sockaddr_in6 *dst,
+                         char *pim_message, int datalen);
 extern int  send_pim6_cand_rp_adv    (void);
 extern void send_pim6_bootstrap  (void);
 

--- a/src/route.h
+++ b/src/route.h
@@ -57,24 +57,24 @@ int change_interfaces(	mrtentry_t *mrtentry_ptr,mifi_t new_iif,
 						u_int16 flags);
 
 extern void      process_kernel_call     (void);
-extern int  set_incoming        __P((srcentry_t *srcentry_ptr,
-                         int srctype));
+extern int  set_incoming        (srcentry_t *srcentry_ptr,
+                         int srctype);
 extern mifi_t   get_iif         (struct sockaddr_in6 *source);
-extern int  add_sg_oif      __P((mrtentry_t *mrtentry_ptr,
+extern int  add_sg_oif      (mrtentry_t *mrtentry_ptr,
                          mifi_t vifi,
                          u_int16 holdtime,
-                         int update_holdtime));
-extern void add_leaf        __P((mifi_t vifi, struct sockaddr_in6 *source,
-                         struct sockaddr_in6 *group));
-extern void delete_leaf     __P((mifi_t vifi, struct sockaddr_in6 *source, 
-                         struct sockaddr_in6 *group));
+                         int update_holdtime);
+extern void add_leaf        (mifi_t vifi, struct sockaddr_in6 *source,
+                         struct sockaddr_in6 *group);
+extern void delete_leaf     (mifi_t vifi, struct sockaddr_in6 *source, 
+                         struct sockaddr_in6 *group);
 
 
 
 
 extern pim_nbr_entry_t *find_pim6_nbr (struct sockaddr_in6 *source);
-extern void calc_oifs       __P((mrtentry_t *mrtentry_ptr,
-                         if_set *oifs_ptr));
+extern void calc_oifs       (mrtentry_t *mrtentry_ptr,
+                         if_set *oifs_ptr);
 extern void process_kernel_call (void);
 extern int  delete_vif_from_mrt (mifi_t vifi);
 extern mrtentry_t *switch_shortest_path (struct sockaddr_in6 *source, struct sockaddr_in6 *group);

--- a/src/routesock.c
+++ b/src/routesock.c
@@ -106,8 +106,8 @@ u_long          rtm_inits;
  * Local functions definitions.
  */
 static int getmsg 
-__P((struct rt_msghdr *, int,
-     struct rpfctl * rpfinfo));
+(struct rt_msghdr *, int,
+     struct rpfctl * rpfinfo);
 
 /*
  * TODO: check again!

--- a/src/rp.c
+++ b/src/rp.c
@@ -157,21 +157,21 @@ u_int8          		static_rp_flag;
 /*
  * Local functions definition.
  */
-static cand_rp_t *add_cand_rp __P((cand_rp_t **used_cand_rp_list ,
-     				   struct sockaddr_in6 *address));
+static cand_rp_t *add_cand_rp (cand_rp_t **used_cand_rp_list ,
+     				   struct sockaddr_in6 *address);
 
-static grp_mask_t *add_grp_mask __P((grp_mask_t ** used_grp_mask_list,
+static grp_mask_t *add_grp_mask (grp_mask_t ** used_grp_mask_list,
 		                     struct sockaddr_in6 *group_addr,
 				     struct in6_addr group_mask,
-				     struct in6_addr hash_mask));
+				     struct in6_addr hash_mask);
 
-static void delete_grp_mask_entry __P((cand_rp_t ** used_cand_rp_list,
+static void delete_grp_mask_entry (cand_rp_t ** used_cand_rp_list,
 			               grp_mask_t ** used_grp_mask_list,
-			               grp_mask_t * grp_mask_delete));
+			               grp_mask_t * grp_mask_delete);
 
-static void delete_rp_entry __P((cand_rp_t ** used_cand_rp_list,
+static void delete_rp_entry (cand_rp_t ** used_cand_rp_list,
 	                         grp_mask_t ** used_grp_mask_list,
-	                         cand_rp_t * cand_rp_ptr));
+	                         cand_rp_t * cand_rp_ptr);
 
 
 void

--- a/src/rp.h
+++ b/src/rp.h
@@ -96,7 +96,7 @@ extern rpentry_t *rp_match      (struct sockaddr_in6 *group);
 extern rp_grp_entry_t *rp_grp_match (struct sockaddr_in6 *group);
 extern int  create_pim6_bootstrap_message (char *send_buff);
 
-extern rp_grp_entry_t *add_rp_grp_entry __P((cand_rp_t  **used_cand_rp_list,
+extern rp_grp_entry_t *add_rp_grp_entry (cand_rp_t  **used_cand_rp_list,
                          grp_mask_t **used_grp_mask_list,
                          struct sockaddr_in6 *rp_addr,
                          u_int8  rp_priority,
@@ -105,25 +105,25 @@ extern rp_grp_entry_t *add_rp_grp_entry __P((cand_rp_t  **used_cand_rp_list,
                          struct sockaddr_in6 *group_addr,
                          struct in6_addr group_mask,
                          struct in6_addr bsr_hash_mask,
-                         u_int16 fragment_tag));
-extern void delete_rp_grp_entry __P((cand_rp_t  **used_cand_rp_list,
+                         u_int16 fragment_tag);
+extern void delete_rp_grp_entry (cand_rp_t  **used_cand_rp_list,
                          grp_mask_t **used_grp_mask_list,
-                         rp_grp_entry_t *rp_grp_entry_delete));
-extern void delete_grp_mask     __P((cand_rp_t  **used_cand_rp_list, 
+                         rp_grp_entry_t *rp_grp_entry_delete);
+extern void delete_grp_mask     (cand_rp_t  **used_cand_rp_list, 
                          grp_mask_t **used_grp_mask_list,  
                          struct sockaddr_in6 *group_addr,
-                         struct in6_addr group_mask));
-extern void delete_rp       __P((cand_rp_t  **used_cand_rp_list,
+                         struct in6_addr group_mask);
+extern void delete_rp       (cand_rp_t  **used_cand_rp_list,
                          grp_mask_t **used_grp_mask_list,
-                         struct sockaddr_in6 *rp_addr));
-extern void delete_rp_list      __P((cand_rp_t  **used_cand_rp_list,
-                         grp_mask_t **used_grp_mask_list));
+                         struct sockaddr_in6 *rp_addr);
+extern void delete_rp_list      (cand_rp_t  **used_cand_rp_list,
+                         grp_mask_t **used_grp_mask_list);
 extern rpentry_t *rp_match      (struct sockaddr_in6 *group); 
 extern rp_grp_entry_t *rp_grp_match (struct sockaddr_in6 *group);
 extern rpentry_t *rp_find       (struct sockaddr_in6 *rp_address);
 extern int  remap_grpentry      (grpentry_t *grpentry_ptr);
-extern int  check_mrtentry_rp   __P((mrtentry_t *mrtentry_ptr,
-                         struct sockaddr_in6 *rp_addr));
+extern int  check_mrtentry_rp   (mrtentry_t *mrtentry_ptr,
+                         struct sockaddr_in6 *rp_addr);
 
 extern void update_rp_neighbor (void);
 #endif

--- a/src/trace.h
+++ b/src/trace.h
@@ -197,6 +197,6 @@ struct tr6_resp {
 
 #define NBR_VERS(n)	(((n)->al_pv << 8) + (n)->al_mv)
 
-void accept_mtrace __P((struct sockaddr_in6 *, struct in6_addr *,
-			struct in6_addr *, int, char *, u_int, int));
+void accept_mtrace (struct sockaddr_in6 *, struct in6_addr *,
+			struct in6_addr *, int, char *, u_int, int);
 #endif /* TRACE_H */

--- a/src/vif.c
+++ b/src/vif.c
@@ -109,8 +109,8 @@ void start_vif (mifi_t vifi);
 void stop_vif (mifi_t vivi);
 int update_reg_vif (mifi_t register_vifi);
 
-extern void add_phaddr __P((struct uvif *, struct sockaddr_in6 *,
-		           struct in6_addr *, struct sockaddr_in6 *));
+extern void add_phaddr (struct uvif *, struct sockaddr_in6 *,
+		           struct in6_addr *, struct sockaddr_in6 *);
 extern int cfparse (int, int);
 
 void


### PR DESCRIPTION
These are patches in order to get this working with `musl` libc. This fixes some wrong includes and removes the deprecated `__P` macros. The `__P` macros are noops and even glibc deprecated them.

With these patches, it's possible to compile on `musl`, but linking fails as [RFC 3542](https://tools.ietf.org/html/rfc3542) isn't implemented. It defaults to the even older API [RFC 2292](https://tools.ietf.org/html/rfc2292), which is also missing.

So the actual functions missing are:

* `inet6_opt_init`
* `inet6_opt_append`
* `inet6_opt_set_val`
* `inet6_opt_finish`

I don't know yet if they can be easily vendored, or reimplemented in some other way. Maybe someone has an Idea.

https://github.com/troglobit/pim6sd/blob/master/src/mld6v2.c#L295-L317

```
Making all in include
make[1]: Entering directory '/builddir/pim6sd-master/include'
make  all-am
make[2]: Entering directory '/builddir/pim6sd-master/include'
make[2]: Leaving directory '/builddir/pim6sd-master/include'
make[1]: Leaving directory '/builddir/pim6sd-master/include'
Making all in src
make[1]: Entering directory '/builddir/pim6sd-master/src'
  YACC     cfparse.c
/builddir/pim6sd-master/src/cfparse.y:151.13-18: warning: POSIX yacc reserves %type to nonterminals [-Wyacc]
  151 | %type <num> LOGLEV NOLOGLEV
      |             ^~~~~~
/builddir/pim6sd-master/src/cfparse.y:151.20-27: warning: POSIX yacc reserves %type to nonterminals [-Wyacc]
  151 | %type <num> LOGLEV NOLOGLEV
      |                    ^~~~~~~~
/builddir/pim6sd-master/src/cfparse.y:152.12-17: warning: POSIX yacc reserves %type to nonterminals [-Wyacc]
  152 | %type <fl> NUMBER
      |            ^~~~~~
/builddir/pim6sd-master/src/cfparse.y:153.13-18: warning: POSIX yacc reserves %type to nonterminals [-Wyacc]
  153 | %type <val> STRING IFNAME
      |             ^~~~~~
/builddir/pim6sd-master/src/cfparse.y:153.20-25: warning: POSIX yacc reserves %type to nonterminals [-Wyacc]
  153 | %type <val> STRING IFNAME
      |                    ^~~~~~
updating cfparse.h
make  all-am
make[2]: Entering directory '/builddir/pim6sd-master/src'
  CC       pim6sd-callout.o
  LEX      cftoken.c
  CC       pim6sd-config.o
  CC       pim6sd-cfparse.o
  CC       pim6sd-crc.o
  CC       pim6sd-inet6.o
  CC       pim6sd-debug.o
  CC       pim6sd-kern.o
  CC       pim6sd-main.o
  CC       pim6sd-mld6.o
  CC       pim6sd-mld6_proto.o
  CC       pim6sd-mld6v2.o
  CC       pim6sd-mld6v2_proto.o
  CC       pim6sd-mrt.o
  CC       pim6sd-netlink.o
mld6.c: In function 'make_mld6_msg':
mld6.c:545:11: warning: implicit declaration of function 'inet6_option_space' [-Wimplicit-function-declaration]
  545 |  hbhlen = inet6_option_space(sizeof(raopt));
      |           ^~~~~~~~~~~~~~~~~~
mld6.c:611:11: warning: implicit declaration of function 'inet6_option_init' [-Wimplicit-function-declaration]
  611 |       if (inet6_option_init((void *)cmsgp, &cmsgp,
      |           ^~~~~~~~~~~~~~~~~
mld6.c:620:11: warning: implicit declaration of function 'inet6_option_append' [-Wimplicit-function-declaration]
  620 |       if (inet6_option_append(cmsgp, raopt, 4, 0))
      |           ^~~~~~~~~~~~~~~~~~~
  CC       pim6sd-routesock.o
mld6v2.c: In function 'make_mld6v2_msg':
mld6v2.c:257:11: warning: implicit declaration of function 'inet6_option_space' [-Wimplicit-function-declaration]
  257 |  hbhlen = inet6_option_space(sizeof(raopt));
      |           ^~~~~~~~~~~~~~~~~~
mld6v2.c:318:6: warning: implicit declaration of function 'inet6_option_init' [-Wimplicit-function-declaration]
  318 |  if (inet6_option_init((void *) cmsgp, &cmsgp,
      |      ^~~~~~~~~~~~~~~~~
mld6v2.c:327:6: warning: implicit declaration of function 'inet6_option_append' [-Wimplicit-function-declaration]
  327 |  if (inet6_option_append(cmsgp, raopt, 4, 0))
      |      ^~~~~~~~~~~~~~~~~~~
  CC       pim6sd-pim6.o
  CC       pim6sd-pim6_proto.o
  CC       pim6sd-route.o
  CC       pim6sd-rp.o
  CC       pim6sd-timer.o
  CC       pim6sd-trace.o
  CC       pim6sd-vif.o
  CC       pim6sd-cftoken.o
  CCLD     pim6sd
/usr/bin/ld: pim6sd-mld6.o: in function `send_mld6':
mld6.c:(.text+0xb54): undefined reference to `inet6_option_init'
/usr/bin/ld: mld6.c:(.text+0xb76): undefined reference to `inet6_option_append'
/usr/bin/ld: mld6.c:(.text+0xc50): undefined reference to `inet6_option_space'
/usr/bin/ld: pim6sd-mld6v2.o: in function `send_mld6v2':
mld6v2.c:(.text+0x618): undefined reference to `inet6_option_space'
/usr/bin/ld: mld6v2.c:(.text+0x6d3): undefined reference to `inet6_option_init'
/usr/bin/ld: mld6v2.c:(.text+0x6f5): undefined reference to `inet6_option_append'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:455: pim6sd] Error 1
make[2]: Leaving directory '/builddir/pim6sd-master/src'
make[1]: *** [Makefile:369: all] Error 2
make[1]: Leaving directory '/builddir/pim6sd-master/src'
make: *** [Makefile:396: all-recursive] Error 1
```