### PR TITLE
Add debian package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+pim6sd (2.1.0-1) stable; urgency=medium
+
+  * Initial release.
+
+ -- Marek Küthe <m.k@mk16.de>  Sat, 14 Dec 2024 19:01:19 +0000

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,19 @@
+Source: pim6sd
+Section: net
+Priority: optional
+Maintainer: Marek Küthe <m.k@mk16.de>
+Rules-Requires-Root: no
+Build-Depends:
+ debhelper-compat (= 13),
+Standards-Version: 4.6.2
+Homepage: https://github.com/troglobit/pim6sd/tree/master
+Vcs-Browser: https://github.com/troglobit/pim6sd/tree/master
+Vcs-Git: https://github.com/troglobit/pim6sd.git
+
+Package: pim6sd
+Architecture: any
+Multi-Arch: foreign
+Depends:
+ ${shlibs:Depends},
+ ${misc:Depends},
+Description: IPv6 Protocol Independent Multicast routing daemon, which supports both Any-Source as well as Source-Specific Multicast, also known as PIM-SM and PIM-SSM.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,16 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Source: https://github.com/troglobit/pim6sd/blob/master/LICENSE
+Upstream-Name: pimd6sd
+Upstream-Contact: Joachim Wiberg <troglobit@gmail.com>
+
+Files: *
+Copyright: Authors
+License: BSD-3-Clause
+
+License: BSD-3-Clause
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,4 @@
+#!/usr/bin/make -f
+
+%:
+	dh $@

--- a/debian/upstream/metadata.ex
+++ b/debian/upstream/metadata.ex
@@ -1,0 +1,7 @@
+# See https://wiki.debian.org/UpstreamMetadata for more info/fields.
+
+Bug-Database: https://github.com/troglobit/pim6sd/issues
+Bug-Submit: https://github.com/troglobit/pim6sd/issues/new
+Changelog: https://github.com/troglobit/pim6sd/blob/master/ChangeLog
+Repository-Browse: https://github.com/troglobit/pim6sd
+Repository: https://github.com/troglobit/pim6sd.git


### PR DESCRIPTION
I have seen that `pimd` is packaged for Debian, but not its IPv6 equivalent. So that I can build it as a package, I created a small debhelper directory. With this you can build a package and install (or uninstall) `pim6sd` as a Debian package.