### PR TITLE
Add option to bypass root check

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -109,6 +109,7 @@ char           		*progname;
 
 static int		foreground = 0;
 static int      	sighandled = 0;
+static int      bypass_root_check = 0;
 
 #define GOT_SIGINT      0x01
 #define GOT_SIGHUP      0x02
@@ -168,6 +169,7 @@ int usage(int rc)
 	   " -f FILE    Configuration file, default: %s\n"
 	   " -h         Show this help text\n"
 	   " -n         Run in foreground, do not detach from controlling terminal\n"
+       " -r         Bypass root check on startup\n"
 	   " -v         Show program version\n"
 	   "\n",
 	   progname, configfilename);
@@ -234,7 +236,7 @@ main(argc, argv)
 
     snprintf(versionstring, sizeof(versionstring), "pim6sd version %s", VERSION);
 
-    while ((ch = getopt(argc, argv, "d:f:hnv")) != EOF) {
+    while ((ch = getopt(argc, argv, "d:f:hnrv")) != EOF) {
 	switch (ch) {
 	case 'd':
 	    debug = debug_parse(optarg);
@@ -256,6 +258,10 @@ main(argc, argv)
 	case 'v':
 	    puts(versionstring);
 	    return 0;
+    
+    case 'r':
+        bypass_root_check = 1;
+        break;
 
 	default:
 	    return usage(1);
@@ -265,7 +271,7 @@ main(argc, argv)
     if (optind < argc)
 	return usage(1);
 
-    if (geteuid() != 0)
+    if (geteuid() != 0 && !bypass_root_check)
 	errx(1, "Need root privileges to start.");
 
     log_fp = stderr;


### PR DESCRIPTION
Hello,

I am trying to create a systemd unit for pim6sd, but it does not work optimally when I have to start it as root. Therefore, it would be nice to have an option to skip the root check.
```
[Unit]
Description=PIM-SM/SSM daemon for IPv6
Documentation=https://github.com/troglobit/pim6sd
After=network.target

[Service]
DynamicUser=true
NoNewPrivileges=true
ProtectSystem=strict
ProtectHome=true
ProtectClock=true
ProtectKernelLogs=true
ProtectKernelTunables=true
ProtectProc=ptraceable
ProtectControlGroups=true
ProtectHostname=true
RestrictSUIDSGID=true
RestrictRealtime=true
PrivateTmp=true
SystemCallArchitectures=native
MemoryDenyWriteExecute=true
LockPersonality=true
ProtectKernelModules=true
CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW
AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
SystemCallFilter=~@clock @cpu-emulation @debug @module @mount @obsolete @privileged @raw-io @reboot @swap @keyring @memlock @setuid
RestrictNamespaces=true

ExecStart=/usr/sbin/pim6sd -f %E/pim6sd/pim6sd.conf -n -d all
Restart=on-failure
RestartSec=5s

RuntimeDirectory=pim6sd
RuntimeDirectoryMode=0755

[Install]
WantedBy=multi-user.target
```



Background: A process, especially a long-running process that has contact with the outside world, should not have to start with privileged access. With the help of the capabilities system, it is possible to assign individual required permissions to the process and thus also dispense with root privileges (example `CapabilityBoundingSet/AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW` in systemd).