### PR TITLE
Remove root check at startup

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -265,9 +265,6 @@ main(argc, argv)
     if (optind < argc)
 	return usage(1);
 
-    if (geteuid() != 0)
-	errx(1, "Need root privileges to start.");
-
     log_fp = stderr;
     setlinebuf(stderr);
 


### PR DESCRIPTION
Background: A process, especially a long-running process that has contact with the outside world, should not have to start with privileged access. With the help of the capabilities system, it is possible to assign individual required permissions to the process and thus also dispense with root privileges (example `CapabilityBoundingSet/AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW` in systemd).

Closes https://github.com/troglobit/pim6sd/pull/39, https://github.com/troglobit/pim6sd/pull/42