### PR TITLE
Change so that the program can start without root privileges

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -266,7 +266,7 @@ main(argc, argv)
 	return usage(1);
 
     if (geteuid() != 0)
-	errx(1, "Need root privileges to start.");
+	fprintf(stderr, "Program was not started with root privileges. Issues may occur.");
 
     log_fp = stderr;
     setlinebuf(stderr);


### PR DESCRIPTION
Background: A process, especially a long-running process that has contact with the outside world, should not have to start with privileged access. With the help of the capabilities system, it is possible to assign individual required permissions to the process and thus also dispense with root privileges (example `CapabilityBoundingSet/AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW` in systemd).

Closes https://github.com/troglobit/pim6sd/pull/40