### PR TITLE
README.md: Clarify distinction between PIM-SM, SSM and ASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 PIM-SM/SSM IPv6 Multicast Routing for UNIX
 ==========================================
 
-pim6sd is an IPv6 Protocol Independent Multicast routing daemon, which
-supports both Any-Source as well as Source-Specific Multicast, also known
-as PIM-SM and PIM-SSM.
+pim6sd is an IPv6 multicast routing daemon for PIM-SM
+(Protocol Independent Multicast - Sparse Mode,
+[RFC7761](https://www.rfc-editor.org/rfc/rfc7761)) and supports both
+Any-Source Multicast (ASM) as well as Source-Specific Multicast (SSM).
+Furthermore it supports ASM with "Embedded-RP" addresses
+([RFC3956](https://www.rfc-editor.org/rfc/rfc3956)).
 
 pim6sd stems from pim6dd, which was originally based on [pimd][], which
 in turn was based on [mrouted][].


### PR DESCRIPTION
The current wording might make it seem as if PIM-SM and PIM-SSM were too separate protocols. However RFC7761 says:

"The Source-Specific Multicast (SSM) service model [6] can be
 implemented with a strict subset of the PIM-SM protocol mechanisms."

And it says:

"An implementer may choose to implement only the subset of PIM
 Sparse Mode that provides SSM forwarding semantics."

So to me it seems that SSM is actually a subset of PIM-SM, not an alternative. And both ASM and SSM are two variants of PIM-SM for a sparse amount of multicast listeners.

A bit confusingly though RFC7761 for PIM-SM never mentions "Any-Source Multicast" / ASM. It calls the ASM variant "regular IP Multicast" or "normal PIM-SM behavior". However RFC8815 seems to use more clear wording to distinguish between ASM vs. SSM as part of PIM-SM.