### PR TITLE
autoconf: fix cross compilation of netlink check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,16 @@ main ()
 	 AC_MSG_RESULT(routing socket)],
 	[AC_DEFINE([HAVE_NETLINK], [1], [Define to 1 if you support the 'netlink' function.])
 	 UK_METHOD=netlink
-	 AC_MSG_RESULT(netlink)])
+	 AC_MSG_RESULT(netlink)],
+	[AC_COMPILE_IFELSE([#include <sys/socket.h>
+#ifndef AF_NETLINK
+#error "Don't have AF_NETLINK"
+#endif
+int main(void) { return 0; }],
+		[AC_DEFINE([HAVE_NETLINK], [1], [Define to 1 if you support the 'netlink' function.])
+		 UK_METHOD=netlink
+		 AC_MSG_RESULT(netlink)],
+		AC_MSG_FAILURE([Could not check userland-kernel interface while cross-compiling]))])
 AC_SUBST(UK_METHOD)
 
 dnl Checks for RFC3542


### PR DESCRIPTION
AC_TRY_RUN() returns an error by default on cross compilation - unless an alternative action is given. For the netlink test such an alternative action is currently missing, which in turn makes an OpenWrt build fail, for instance.

For cross compiled binaries it does not make sense to test the netlink interface against the compiling host. ~~Therefore just skip the netlink runtime check on cross compilation with a warning.~~ Therefore only do a compile
time test to check for the availability of netlink when cross-compiling.