### PR TITLE
Fix musl build RFC3542/RFC2292 limitations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,9 @@ AC_SUBST(UK_METHOD)
 dnl Checks for RFC3542
 AC_CHECK_LIB([c], [inet6_opt_init], [AC_DEFINE([HAVE_RFC3542], [1], [Define to 1 if you support RFC3542])], )
 
+dnl Checks for RFC2292
+AC_CHECK_LIB([c], [inet6_option_append], [AC_DEFINE([HAVE_RFC2292], [1], [Define to 1 if you support RFC2292])], )
+
 # Generate all files
 AC_OUTPUT
 

--- a/src/mld6.c
+++ b/src/mld6.c
@@ -496,6 +496,164 @@ accept_mld6(recvlen)
 	}
 }
 
+static int mld_get_hbhlen(void)
+{
+    int hbhlen;
+
+#ifdef HAVE_RFC3542
+    hbhlen = inet6_opt_init(NULL, 0);
+    if (hbhlen == -1)
+        log_msg(LOG_ERR, 0, "inet6_opt_init(0) failed");
+
+    hbhlen = inet6_opt_append(NULL, 0, hbhlen, IP6OPT_ROUTER_ALERT, 2, 2, NULL);
+    if (hbhlen == -1)
+        log_msg(LOG_ERR, 0, "inet6_opt_append(0) failed");
+
+    hbhlen = inet6_opt_finish(NULL, 0, hbhlen);
+    if (hbhlen == -1)
+        log_msg(LOG_ERR, 0, "inet6_opt_finish(0) failed");
+#else  /* old advanced API */
+    hbhlen = inet6_option_space(sizeof(raopt));
+#endif
+
+    return hbhlen;
+}
+
+#ifdef HAVE_RFC3542
+static struct cmsghdr *
+mld_append_rtalert_rfc3542(struct cmsghdr *cmsgp, int hbhlen)
+{
+    int currentlen;
+    void *hbhbuf, *optp = NULL;
+
+    cmsgp->cmsg_len = CMSG_LEN(hbhlen);
+    cmsgp->cmsg_level = IPPROTO_IPV6;
+    cmsgp->cmsg_type = IPV6_HOPOPTS;
+    hbhbuf = CMSG_DATA(cmsgp);
+
+    if ((currentlen = inet6_opt_init(hbhbuf, hbhlen)) == -1)
+	    log_msg(LOG_ERR, 0, "inet6_opt_init(len = %d) failed",
+		hbhlen);
+    currentlen = inet6_opt_append(hbhbuf, hbhlen, currentlen,
+				  IP6OPT_ROUTER_ALERT, 2, 2, &optp);
+    if (currentlen == -1)
+	    log_msg(LOG_ERR, 0, "inet6_opt_append(len = %d/%d) failed",
+		    currentlen, hbhlen);
+
+    (void)inet6_opt_set_val(optp, 0, &rtalert_code, sizeof(rtalert_code));
+    if (inet6_opt_finish(hbhbuf, hbhlen, currentlen) == -1)
+        log_msg(LOG_ERR, 0, "inet6_opt_finish(buf) failed");
+
+    return CMSG_NXTHDR(&sndmh, cmsgp);
+}
+#else
+static struct cmsghdr *
+mld_append_rtalert_rfc2292(struct cmsghdr *cmsgp, int hbhlen)
+{
+    if (inet6_option_init((void *)cmsgp, &cmsgp,
+#ifdef IPV6_2292HOPOPTS
+        IPV6_2292HOPOPTS
+#else
+        IPV6_HOPOPTS
+#endif
+                    ))
+        log_msg(LOG_ERR, errno, /* assert */
+                "make_mld6_msg: inet6_option_init failed");
+
+    if (inet6_option_append(cmsgp, raopt, 4, 0))
+        log_msg(LOG_ERR, errno, /* assert */
+                "make_mld6_msg: inet6_option_append failed");
+
+    return CMSG_NXTHDR(&sndmh, cmsgp);
+}
+#endif /* HAVE_RFC3542 */
+
+struct cmsghdr *mld_append_rtalert(struct cmsghdr *cmsgp, int hbhlen)
+{
+#ifdef HAVE_RFC3542
+    return mld_append_rtalert_rfc3542(cmsgp, hbhlen);
+#else  /* old advanced API */
+    return mld_append_rtalert_rfc2292(cmsgp, hbhlen);
+#endif
+}
+
+static int mld_ctllen(int len)
+{
+#ifdef HAVE_RFC3542
+    return CMSG_SPACE(len);
+#else
+    return len;
+#endif
+}
+
+static struct cmsghdr *
+mld_fill_pktinfo(struct cmsghdr *cmsgp, int ifindex, struct sockaddr_in6 *src)
+{
+    struct in6_pktinfo *pktinfo;
+
+    cmsgp->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
+    cmsgp->cmsg_level = IPPROTO_IPV6;
+    cmsgp->cmsg_type = IPV6_PKTINFO;
+    pktinfo = (struct in6_pktinfo *)CMSG_DATA(cmsgp);
+    memset((caddr_t)pktinfo, 0, sizeof(*pktinfo));
+    if (ifindex != -1)
+	    pktinfo->ipi6_ifindex = ifindex;
+    if (src)
+	    pktinfo->ipi6_addr = src->sin6_addr;
+
+    return CMSG_NXTHDR(&sndmh, cmsgp);
+}
+
+void mld_fill_msg(int ifindex, struct sockaddr_in6 *src, int alert, int datalen)
+{
+    struct cmsghdr *cmsgp;
+    int ctllen, hbhlen;
+
+    sndiov[0].iov_len = datalen;
+
+    /* estimate total ancillary data length */
+    ctllen = 0;
+    if (ifindex != -1 || src)
+	    ctllen += CMSG_SPACE(sizeof(struct in6_pktinfo));
+    if (alert) {
+        hbhlen = mld_get_hbhlen();
+        ctllen += mld_ctllen(hbhlen);
+    }
+    /* extend ancillary data space (if necessary) */
+    if (ctlbuflen < ctllen) {
+	    if (sndcmsgbuf)
+		    free(sndcmsgbuf);
+	    sndcmsgbuf = calloc(1, ctllen);
+	    if (!sndcmsgbuf)
+		    log_msg(LOG_ERR, errno, "Failed allocating send buffer"); /* assert */
+	    ctlbuflen = ctllen;
+    }
+
+    if (ctllen <= 0) {
+        sndmh.msg_control = NULL;	/* clear for safety */
+        return;
+    }
+
+    /* store ancillary data */
+    sndmh.msg_flags = 0;
+    sndmh.msg_control = sndcmsgbuf;
+    sndmh.msg_controllen = ctllen;
+
+    cmsgp = CMSG_FIRSTHDR(&sndmh);
+    if (!cmsgp)
+	    log_msg(LOG_ERR, 0, "Internal error 1 in %s", __func__);
+
+    if (ifindex != -1 || src)
+	    cmsgp = mld_fill_pktinfo(cmsgp, ifindex, src);
+
+    if (alert) {
+        if (!cmsgp)
+            log_msg(LOG_ERR, 0, "Internal error 2 in %s", __func__);
+
+        cmsgp = mld_append_rtalert(cmsgp, hbhlen);
+    }
+}
+
 static void
 make_mld6_msg(type, code, src, dst, group, ifindex, delay, datalen, alert)
     int type, code, ifindex, delay, datalen, alert;
@@ -503,7 +661,6 @@ make_mld6_msg(type, code, src, dst, group, ifindex, delay, datalen, alert)
     struct in6_addr *group;
 {
     struct mld_hdr *mhp = (struct mld_hdr *)mld6_send_buf;
-    int ctllen, hbhlen = 0;
 
     init_sin6(&dst_sa);
 
@@ -531,107 +688,7 @@ make_mld6_msg(type, code, src, dst, group, ifindex, delay, datalen, alert)
     mhp->mld_maxdelay = htons(delay);
     mhp->mld_addr = *group;
 
-    sndiov[0].iov_len = datalen;
-
-    /* estimate total ancillary data length */
-    ctllen = 0;
-    if (ifindex != -1 || src)
-	    ctllen += CMSG_SPACE(sizeof(struct in6_pktinfo));
-    if (alert) {
-#ifdef HAVE_RFC3542
-	if ((hbhlen = inet6_opt_init(NULL, 0)) == -1)
-		log_msg(LOG_ERR, 0, "inet6_opt_init(0) failed");
-	if ((hbhlen = inet6_opt_append(NULL, 0, hbhlen, IP6OPT_ROUTER_ALERT, 2,
-				       2, NULL)) == -1)
-		log_msg(LOG_ERR, 0, "inet6_opt_append(0) failed");
-	if ((hbhlen = inet6_opt_finish(NULL, 0, hbhlen)) == -1)
-		log_msg(LOG_ERR, 0, "inet6_opt_finish(0) failed");
-	ctllen += CMSG_SPACE(hbhlen);
-#else  /* old advanced API */
-	hbhlen = inet6_option_space(sizeof(raopt));
-	ctllen += hbhlen;
-#endif
-    }
-    /* extend ancillary data space (if necessary) */
-    if (ctlbuflen < ctllen) {
-	    if (sndcmsgbuf)
-		    free(sndcmsgbuf);
-	    sndcmsgbuf = calloc(1, ctllen);
-	    if (!sndcmsgbuf)
-		    log_msg(LOG_ERR, errno, "Failed allocating send buffer"); /* assert */
-	    ctlbuflen = ctllen;
-    }
-
-    if (ctllen > 0) {
-	    struct cmsghdr *cmsgp;
-
-	    /* store ancillary data */
-	    sndmh.msg_flags = 0;
-	    sndmh.msg_control = sndcmsgbuf;
-	    sndmh.msg_controllen = ctllen;
-
-	    cmsgp = CMSG_FIRSTHDR(&sndmh);
-	    if (!cmsgp)
-		    log_msg(LOG_ERR, 0, "Internal error 1 in %s", __func__);
-
-	    if (ifindex != -1 || src) {
-		    struct in6_pktinfo *pktinfo;
-
-		    cmsgp->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
-		    cmsgp->cmsg_level = IPPROTO_IPV6;
-		    cmsgp->cmsg_type = IPV6_PKTINFO;
-		    pktinfo = (struct in6_pktinfo *)CMSG_DATA(cmsgp);
-		    memset((caddr_t)pktinfo, 0, sizeof(*pktinfo));
-		    if (ifindex != -1)
-			    pktinfo->ipi6_ifindex = ifindex;
-		    if (src)
-			    pktinfo->ipi6_addr = src->sin6_addr;
-		    cmsgp = CMSG_NXTHDR(&sndmh, cmsgp);
-	    }
-	    if (alert) {
-#ifdef HAVE_RFC3542
-		    int currentlen;
-		    void *hbhbuf, *optp = NULL;
-
-		    if (!cmsgp)
-			    log_msg(LOG_ERR, 0, "Internal error 2 in %s", __func__);
-
-		    cmsgp->cmsg_len = CMSG_LEN(hbhlen);
-		    cmsgp->cmsg_level = IPPROTO_IPV6;
-		    cmsgp->cmsg_type = IPV6_HOPOPTS;
-		    hbhbuf = CMSG_DATA(cmsgp);
-
-		    if ((currentlen = inet6_opt_init(hbhbuf, hbhlen)) == -1)
-			    log_msg(LOG_ERR, 0, "inet6_opt_init(len = %d) failed",
-				hbhlen);
-		    currentlen = inet6_opt_append(hbhbuf, hbhlen, currentlen,
-						  IP6OPT_ROUTER_ALERT, 2, 2, &optp);
-		    if (currentlen == -1)
-			    log_msg(LOG_ERR, 0, "inet6_opt_append(len = %d/%d) failed",
-				    currentlen, hbhlen);
-
-		    (void)inet6_opt_set_val(optp, 0, &rtalert_code, sizeof(rtalert_code));
-		    if (inet6_opt_finish(hbhbuf, hbhlen, currentlen) == -1)
-			    log_msg(LOG_ERR, 0, "inet6_opt_finish(buf) failed");
-#else  /* old advanced API */
-		    if (inet6_option_init((void *)cmsgp, &cmsgp,
-#ifdef IPV6_2292HOPOPTS
-		        IPV6_2292HOPOPTS
-#else
-		        IPV6_HOPOPTS
-#endif
-			))
-			    log_msg(LOG_ERR, errno, /* assert */
-				"make_mld6_msg: inet6_option_init failed");
-		    if (inet6_option_append(cmsgp, raopt, 4, 0))
-			    log_msg(LOG_ERR, errno, /* assert */
-				"make_mld6_msg: inet6_option_append failed");
-#endif 
-		    cmsgp = CMSG_NXTHDR(&sndmh, cmsgp);
-	    }
-    }
-    else
-	    sndmh.msg_control = NULL; /* clear for safety */
+    mld_fill_msg(ifindex, src, alert, datalen);
 }
 
 int

--- a/src/mld6.h
+++ b/src/mld6.h
@@ -68,6 +68,7 @@ void free_mld6 (void);
 int send_mld6 (int type, int code, struct sockaddr_in6 *src,
 		   struct sockaddr_in6 *dst, struct in6_addr *group,
 		   int index, int delay, int datalen, int alert);
+void mld_fill_msg(int ifindex, struct sockaddr_in6 *src, int alert, int datalen);
 
 #ifndef MLD_LISTENER_QUERY
 #  ifdef MLD6_LISTENER_QUERY


### PR DESCRIPTION
The first patch is just some code cleanup and unification, in preparation for the second patch. The second patch implements yet another mechanism to insert a hop-by-hop header with a router alert option, as musl currently neither implements the RFC3542 `inet6_opt_*()` functions nor the RFC2292 `inet6_option_*()` functions.

This partially/mostly fixes #24. Only a few unrelated linker errors seem to be missing for an OpenWrt musl build after that.