### PR TITLE
linux: fix pim header on big-endian bitfield builds

### DIFF
--- a/include/linux/pim.h
+++ b/include/linux/pim.h
@@ -10,7 +10,7 @@ struct pim {
 	__u8	pim_type:4,		/* PIM message type */
 		pim_ver:4;		/* PIM version */
 #elif defined(__BIG_ENDIAN_BITFIELD)
-	__u8	pim_ver:4;		/* PIM version */
+	__u8	pim_ver:4,		/* PIM version */
 		pim_type:4;		/* PIM message type */
 #endif
 	__u8	pim_rsv;		/* Reserved */


### PR DESCRIPTION
When building pim6sd for a big-endian bitfield architecture, like Octeon via the OpenWrt SDK, then the following build error occurs:

```
$ gcc [...] -o pim6sd-callout.o `test -f 'callout.c' || echo './'`callout.c
In file included from defs.h:110,
                 from callout.c:31:
../include/linux/pim.h:14:17: error: expected specifier-qualifier-list before 'pim_type'
   14 |                 pim_type:4;             /* PIM message type */
      |                 ^~~~~~~~
```

This happens due to a typo where the line above uses a semicolon instead of a comma, leading to a missing type for the following pim_type. However the pim_type should share the __u8 type with pim_ver above.

The little-endian bitfield variant doesn't have this typo though.